### PR TITLE
add license information to the gemspec

### DIFF
--- a/platform.gemspec
+++ b/platform.gemspec
@@ -16,4 +16,5 @@ SPEC = Gem::Specification.new do |s|
    s.autorequire = "platform" 
    s.has_rdoc = true 
    s.extra_rdoc_files = ["README"] 
+   s.license = "LGPL"
 end 


### PR DESCRIPTION
Please accept this PR. This way it can be queried using the rubygems.org API
